### PR TITLE
Double wildcard paths like collection** on change events (missing return value)

### DIFF
--- a/index.js
+++ b/index.js
@@ -423,6 +423,7 @@ function relevantPath (pattern, relativeSegments) {
   if (pattern === '**') return [null].concat(relativeSegments);
   // Check for patterns "collection**" or e.g., "collection.*.x.y.z**"
   if (pattern.slice(pattern.length-2, pattern.length) === '**') {
+    return true;
   } else {
     // Handle e.g., pattern = "collection.*.x.y.z"
     var patternSegments = pattern.split('.');


### PR DESCRIPTION
I can't get hooks like `store.allow('change', 'collection**')` or `store.allow('change', 'collection.**')` to work, any validations added on such paths will never trigger. `store.allow('all', 'collection**')` still triggers fine, which I think has to do with `_allow_all` checking manually for those kind of paths. Are these patterns not available for change events? Is the missing return value a bug or was it intended? 

**How can I capture all changes under a specific collection?**

(Edit: I just realised these changes are wrong, relativePath should perhaps return something like `[null].concat(relativeSegments)`?)
