### PR TITLE
Run tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"
+services:
+  - redis-server

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "expect.js": "*"
   },
   "scripts": {
-    "test": "mocha --compilers .coffee:coffee-script test.coffee"
+    "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script/register test/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Use devDependencies mocha for `$ npm test`
- Correct path to tests for `$ npm test`
- Correct mocha compiler flag for coffeescript >= 1.6
- Configure Travis CI to test against both node 0.10 and 0.11

Happy to split this if travis support is undesirable.
